### PR TITLE
Moving the repo to the central D9 onboarding folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 
+# This has moved to https://github.com/Dome9/onboarding-scripts
+# Please check there for all future updates
+
+
 # Dome9-OnBoarding-CFT
 CloudFormation Template that Prepare Role on AWS account to connenct to Dome9 
 


### PR DESCRIPTION
Roy wants this folder to be moved into this directory:
https://github.com/Dome9/onboarding-scripts

This is just to update the readme to reflect that